### PR TITLE
Update URL in README.md

### DIFF
--- a/lessons/1-Intro/README.md
+++ b/lessons/1-Intro/README.md
@@ -112,7 +112,7 @@ Similarly, we can see how the approach towards creating “talking programs” (
 
 * Early programs of this kind such as [Eliza](https://en.wikipedia.org/wiki/ELIZA), were based on very simple grammatical rules and the re-formulation of the input sentence into a question.
 * Modern assistants, such as Cortana, Siri or Google Assistant are all hybrid systems that use Neural networks to convert speech into text and recognize our intent, and then employ some reasoning or explicit algorithms to perform required actions.
-* In the future, we may expect a complete neural-based model to handle dialogue by itself. The recent GPT and [Turing-NLG](https://turing.microsoft.com/) family of neural networks show great success in this.
+* In the future, we may expect a complete neural-based model to handle dialogue by itself. The recent GPT and [Turing-NLG](https://www.microsoft.com/en-us/research/blog/turing-nlg-a-17-billion-parameter-language-model-by-microsoft/) family of neural networks show great success in this.
 
 <img alt="the Turing test's evolution" src="images/turing-test-evol.png" width="70%"/>
 


### PR DESCRIPTION
The link is currently referring to turing.microsoft.com, which seems to be a retired subdomain, and redirects to careers.microsoft.com. The correct url should refer to this essay: "Turing-NLG: A 17-billion-parameter language model by Microsoft", published on Microsoft Research Blog by Corby Rosset, 02/13/2020.